### PR TITLE
MultiGet fix + gas optimization

### DIFF
--- a/contracts/Pythia.sol
+++ b/contracts/Pythia.sol
@@ -4,18 +4,18 @@ pragma solidity >=0.8.2 <0.9.0;
 contract Pythia {
 
     struct Data {
-        uint value;
-        uint lastUpdate;
+        uint224 value;
+        uint32 lastUpdate;
     }
 
     mapping(address => mapping(address => mapping(bytes32 => Data))) data;
 
 
-    function set(address asset, bytes32 key, uint value, uint updateTime) public {
+    function set(address asset, bytes32 key, uint224 value, uint32 updateTime) public {
         data[msg.sender][asset][key] = Data(value, updateTime);
     }
 
-    function multiSet(address[] calldata assets, bytes32[] calldata keys, uint[] calldata values, uint[] calldata updateTimes) external {
+    function multiSet(address[] calldata assets, bytes32[] calldata keys, uint224[] calldata values, uint32[] calldata updateTimes) external {
         require(assets.length == keys.length, "invalid input length");
 
         for(uint i = 0 ; i < assets.length; i++) {


### PR DESCRIPTION
# MultiGet fix:
The parameters relayers[i] and assets[i] were interverted in the for loop calling the get function

# Gas optimization:
Instead of storing two uint256 for value and lastUpdate, we now use uint224 for value and uint32 for lastUpdate, meaning the data will fit into a 256 bit data storage block. ~50% gas usage reduction

Example for MultiSet call with 9 values before this optimization: [sepolia tx](https://sepolia.etherscan.io/tx/0xc4de0ebdd07184559f4c1262e03d8d80313711112f3cc906f05c32093d46945c)
gas usage = 442,622
Transaction cost on sepolia: 0.00066396 = $1.32792 with ETH at $2000



Example of the same MultiSet with 9 values after optimization: [sepolia tx](https://sepolia.etherscan.io/tx/0x1387927ebb369e7f19ffac51885e8b5dddfa6adb8145ec46e547fe10f3358d69)
gas usage = 251,712
Transaction cost on sepolia: 0.00037757 = $0.75514 with ETH at $2000

**Drawback for this optimization:**
**1/ lastUpdate limit**
uint32 as the limit for a timestamp in seconds means that the max date that will be stored in the pythia contract will be Sun Feb 07 2106 06:28:15 GMT+0000

So if the pythia contract should work without any modification for more than ~83 years, this optimization cannot work

**2/ liquidity limit**
uint224 for the value field means a max liquidity (in wei) of 26959946667150639794667015087019630673637144422540572481103610249215

Should be enough for our use case

