### PR TITLE
BProtocolMorphoAllocator is now Ownable

### DIFF
--- a/src/morpho/BProtocolMorphoAllocator.sol
+++ b/src/morpho/BProtocolMorphoAllocator.sol
@@ -7,6 +7,7 @@ import {IMetaMorpho, MarketAllocation, Id, MarketParams, IMorpho, MathLib, WAD, 
 import {RiskyMath} from "../lib/RiskyMath.sol";
 import {MorphoLib} from "../external/Morpho.sol";
 import {ErrorLib} from "../lib/ErrorLib.sol";
+import "../../lib/openzeppelin-contracts/contracts/access/Ownable.sol";
 
 /*  
 USDC/sDAI
@@ -34,7 +35,7 @@ marketid: 0xbc6d1789e6ba66e5cd277af475c5ed77fcf8b084347809d9d92e400ebacbdd10
 ///         It needs to have the Allocator role in the MetaMorpho vault
 /// @dev The contract uses immutable state variables for SmartLTV, trusted relayer, and MetaMorpho Vault addresses.
 ///      It includes functionality to check allocation risks and perform reallocation based on these assessments.
-contract BProtocolMorphoAllocator {
+contract BProtocolMorphoAllocator is Ownable {
   using MathLib for uint256;
 
   /// @notice The SmartLTV contract used for loan-to-value calculations
@@ -46,7 +47,7 @@ contract BProtocolMorphoAllocator {
   /// @notice A predefined constant representing the minimum confidence level factor
   uint256 public immutable MIN_CLF = 3e18;
 
-  constructor(SmartLTV smartLTV, address morphoVaultAddress) {
+  constructor(SmartLTV smartLTV, address morphoVaultAddress, address initialOwner) Ownable(initialOwner) {
     SMART_LTV = smartLTV;
     METAMORPHO_VAULT = IMetaMorpho(morphoVaultAddress);
   }
@@ -63,7 +64,7 @@ contract BProtocolMorphoAllocator {
     MarketAllocation[] calldata allocations,
     RiskData[] calldata riskDatas,
     Signature[] calldata signatures
-  ) external {
+  ) external onlyOwner {
     if (allocations.length != riskDatas.length) {
       revert ErrorLib.INVALID_RISK_DATA_COUNT(allocations.length, riskDatas.length);
     }

--- a/test/integration/IntegrationTestReallocateFlow.sol
+++ b/test/integration/IntegrationTestReallocateFlow.sol
@@ -105,7 +105,7 @@ contract IntegrationTestReallocateFlow is MorphoFixture {
 
   /// @notice Tests the reallocation process for the USDT market.
   /// @dev Simulates rebalancing between SDAI and USDT markets and checks supply changes.
-  function testReallocateToMarketUSDT() public {
+  function testReallocateToMarketUSDT(uint256 removeFromSdaiSeed) public {
     // get and log morpho blue markets
     computeMarketChange(marketIdSDAI);
     computeMarketChange(marketIdUSDT);
@@ -123,8 +123,10 @@ contract IntegrationTestReallocateFlow is MorphoFixture {
     RiskData[] memory riskDatas = new RiskData[](2);
     Signature[] memory signatures = new Signature[](2);
 
+    // divide the current sdai allocation by a factor of 2 to 100
+    uint256 sDaiDividingFactor = bound(removeFromSdaiSeed, 2, 100);
     // first allocation is the withdraw from the sdai parameter
-    uint256 targetSdaiSupply = sDaiSupplyBefore / 2;
+    uint256 targetSdaiSupply = sDaiSupplyBefore / sDaiDividingFactor;
     console2.log("targetSdaiSupply: %s", targetSdaiSupply);
     allocations[0] = MarketAllocation({marketParams: marketParamSDAI, assets: targetSdaiSupply});
     // second allocation is the supply to the usdt market

--- a/test/integration/IntegrationTestReallocateFlow.sol
+++ b/test/integration/IntegrationTestReallocateFlow.sol
@@ -105,7 +105,7 @@ contract IntegrationTestReallocateFlow is MorphoFixture {
 
   /// @notice Tests the reallocation process for the USDT market.
   /// @dev Simulates rebalancing between SDAI and USDT markets and checks supply changes.
-  function testReallocateToMarketUSDT(uint256 removeFromSdaiSeed) public {
+  function testReallocateToMarketUSDT() public {
     // get and log morpho blue markets
     computeMarketChange(marketIdSDAI);
     computeMarketChange(marketIdUSDT);
@@ -124,9 +124,8 @@ contract IntegrationTestReallocateFlow is MorphoFixture {
     Signature[] memory signatures = new Signature[](2);
 
     // divide the current sdai allocation by a factor of 2 to 100
-    uint256 sDaiDividingFactor = bound(removeFromSdaiSeed, 2, 100);
     // first allocation is the withdraw from the sdai parameter
-    uint256 targetSdaiSupply = sDaiSupplyBefore / sDaiDividingFactor;
+    uint256 targetSdaiSupply = sDaiSupplyBefore / 2;
     console2.log("targetSdaiSupply: %s", targetSdaiSupply);
     allocations[0] = MarketAllocation({marketParams: marketParamSDAI, assets: targetSdaiSupply});
     // second allocation is the supply to the usdt market
@@ -168,6 +167,7 @@ contract IntegrationTestReallocateFlow is MorphoFixture {
 
     signatures[1] = Signature({v: v, r: r, s: s});
 
+    vm.prank(allocatorOwner);
     morphoAllocator.checkAndReallocate(allocations, riskDatas, signatures);
 
     computeMarketChange(marketIdSDAI);
@@ -241,6 +241,7 @@ contract IntegrationTestReallocateFlow is MorphoFixture {
     signatures[1] = signatures[0];
     signatures[2] = signatures[0];
 
+    vm.prank(allocatorOwner);
     morphoAllocator.checkAndReallocate(allocations, riskDatas, signatures);
 
     computeMarketChange(marketIdSDAI);

--- a/test/integration/MorphoFixture.sol
+++ b/test/integration/MorphoFixture.sol
@@ -24,6 +24,7 @@ contract MorphoFixture is Test {
 
   uint256 trustedRelayerPrivateKey = 0x42;
   address trustedRelayerAddress = vm.addr(trustedRelayerPrivateKey);
+  address allocatorOwner = address(101);
 
   // fake function so that does not show up in the coverage report
   function test() public {}
@@ -32,7 +33,7 @@ contract MorphoFixture is Test {
     // create pythia, smartLTV and BProtocolMorphoAllocator contract
     pythia = new Pythia();
     smartLTV = new SmartLTV(pythia, trustedRelayerAddress);
-    morphoAllocator = new BProtocolMorphoAllocator(smartLTV, address(metaMorpho));
+    morphoAllocator = new BProtocolMorphoAllocator(smartLTV, address(metaMorpho), allocatorOwner);
 
     // gives the allocator role to the BProtocolMorphoAllocator contract
     address ownerAddress = metaMorpho.owner();


### PR DESCRIPTION
And the check before reallocate is behind the onlyOwner attribute